### PR TITLE
Add console levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ React.createClass({
 
 (MIT License)
 
-Copyright (c) 2015 Contra <yo@contra.io>
+Copyright (c) 2016 Contra <yo@contra.io>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/index.js
+++ b/index.js
@@ -3,20 +3,16 @@
 var slice = require('array-slice');
 var console = require('console');
 
-module.exports = {
-  dir: function() {
+var levels = ['log', 'dir', 'error', 'count', 'info'];
+
+var logger = {};
+
+levels.forEach(function (level) {
+  logger[level] = function() {
     var args = slice(arguments);
     args.unshift('[' + this.constructor.displayName + ']');
-    console.dir.apply(console, args);
-  },
-  log: function() {
-    var args = slice(arguments);
-    args.unshift('[' + this.constructor.displayName + ']');
-    console.log.apply(console, args);
-  },
-  error: function() {
-    var args = slice(arguments);
-    args.unshift('[' + this.constructor.displayName + ']');
-    console.error.apply(console, args);
-  }
-};
+    console[level].apply(console, args);
+  };
+});
+
+module.exports = logger;

--- a/test/index.js
+++ b/test/index.js
@@ -15,11 +15,19 @@ describe('logger', function() {
     done();
   });
   it('should be able to call dir', function(done) {
-    logger.dir.call(dummy, 'test', 123);
+    logger.dir.call(dummy);
     done();
   });
   it('should be able to call error', function(done) {
-    //logger.error.call(dummy, 'test', 123);
+    // logger.error.call(dummy, 'test', 123);
+    done();
+  });
+  it('should be able to call count', function(done) {
+    logger.count.call(dummy);
+    done();
+  });
+  it('should be able to call info', function(done) {
+    logger.info.call(dummy, 'test', 123);
     done();
   });
 });


### PR DESCRIPTION
Add console levels specified in issue #2, but exclude deprecated level `debug` and also exclude `exception` as it is an alias for `error`.
